### PR TITLE
Using YAML configs. Implemented Validity checker/writer.

### DIFF
--- a/config.yaml
+++ b/config.yaml
@@ -1,0 +1,4 @@
+ca: {
+    cer_filename: "/Users/sschulte/code/r509/cert_data/test_ca/test_ca.cer",
+    key_filename: "/Users/sschulte/code/r509/cert_data/test_ca/test_ca.key"
+}

--- a/ocsp-responder.gemspec
+++ b/ocsp-responder.gemspec
@@ -9,6 +9,9 @@ spec = Gem::Specification.new do |s|
   s.summary = "A (relatively) simple OCSP responder written to work with r509"
   s.description = 'An OCSP responder. What, you want more info?'
   s.add_dependency 'r509'
+  s.add_dependency 'redis'
+  s.add_dependency 'SystemTimer'
+  s.add_dependency 'yaml'
   s.add_development_dependency 'rspec'
   s.add_development_dependency 'syntax'
   s.author = "Paul Kehrer"


### PR DESCRIPTION
YAML configs contain filenames of CA CER/KEY files.

ValidityChecker and ValidityWriter use a Redis backend. The OCSP responder doesn't actually need a ValidityWriter, but I wrote it anyway.
