### PR TITLE
Fixing #<TypeError: no implicit conversion of String into Integer>

### DIFF
--- a/lib/r509/ocsp/signer.rb
+++ b/lib/r509/ocsp/signer.rb
@@ -196,7 +196,7 @@ module R509::OCSP::Helper
         end
         basic_response.add_status(status[:certid],
                     status[:status],
-                    status[:revocation_reason],
+                    status[:revocation_reason].to_i,
                     revocation_time,
                     -1*status[:config].ocsp_start_skew_seconds,
                     status[:config].ocsp_validity_hours*3600,


### PR DESCRIPTION
I had a revoked cert with revocation reason 0, while using r509-validity-crl as the information source.

Checking the status of good certs resulted in a a response, whereas checking the status of a revoked certed resulted in 500 internal server error:

 #<TypeError: no implicit conversion of String into Integer>
E, [2016-02-26T20:54:17.154753 #26930] ERROR -- : /usr/local/share/gems/gems/r509-ocsp-responder-0.3.3/lib/r509/ocsp/signer.rb:198:in `add_status'

Explicitly casting status[:revocation_reason] to an integer solved the problem and the revoked response was returned to the client.