### PR TITLE
Support Ruby 2.4

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,10 +1,9 @@
 language: ruby
 rvm:
- - 1.9.3
- - 2.0.0
- - 2.1.0
+ - 2.2.0
+ - 2.3.0
+ - 2.4.0
  - ruby-head
- - rbx
 matrix:
   allow_failures:
     - rvm: ruby-head

--- a/Gemfile
+++ b/Gemfile
@@ -8,6 +8,7 @@ platforms :rbx do
     gem "rubinius-coverage"
 end
 gem "r509"
+gem "openssl"
 gem "r509-validity-redis"
 gem "dependo"
 gemspec

--- a/Gemfile
+++ b/Gemfile
@@ -8,7 +8,6 @@ platforms :rbx do
     gem "rubinius-coverage"
 end
 gem "r509"
-gem "openssl"
 gem "r509-validity-redis"
 gem "dependo"
 gemspec

--- a/Rakefile
+++ b/Rakefile
@@ -16,7 +16,7 @@ namespace :gem do
 
     desc 'Install gem'
     task :install do
-        puts `gem install r509-ocsp-responder-#{R509::Ocsp::Responder::VERSION}.gem`
+        puts `gem install r509-ocsp-responder-#{R509::OCSP::Responder::VERSION}.gem`
     end
 
     desc 'Uninstall gem'

--- a/lib/r509/ocsp/signer.rb
+++ b/lib/r509/ocsp/signer.rb
@@ -72,7 +72,7 @@ module R509::OCSP::Helper
         @configs_hash = {}
         @configs.each do |config|
           ee_cert = OpenSSL::X509::Certificate.new
-          ee_cert.issuer = config.ca_cert.cert.subject.name
+          ee_cert.issuer = config.ca_cert.cert.subject
           # per RFC 5019
           # Clients MUST use SHA1 as the hashing algorithm for the
           # CertID.issuerNameHash and the CertID.issuerKeyHash values.
@@ -211,7 +211,8 @@ module R509::OCSP::Helper
       #confusing, but R509::Cert contains R509::PrivateKey under #key. PrivateKey#key gives the OpenSSL object
       #turns out BasicResponse#sign can take up to 4 params
       #cert, key, array of OpenSSL::X509::Certificates, flags (not sure what the enumeration of those are)
-      basic_response.sign(config.ocsp_cert.cert,config.ocsp_cert.key.key,config.ocsp_chain)
+      signature_algorithm = "SHA256"
+      basic_response.sign(config.ocsp_cert.cert, config.ocsp_cert.key.key, config.ocsp_chain, 0, signature_algorithm)
     end
 
     # Builds final response.


### PR DESCRIPTION
Ruby2.4 changed the version of OpenSSL, this change updates usage of
OpenSSL to work with the changes to the library.

This change also updates the responder signature to use SHA256 as SHA1
is on a deprecation path in most browsers.


Unit Tests
=======================
[Coveralls] Outside the CI environment, not sending data.
~/w/r509-ocsp-responder ❯❯❯ ruby --version
ruby 2.4.1p111 (2017-03-22 revision 58053) [x86_64-darwin16]
~/w/r509-ocsp-responder ❯❯❯ rspec -fp
[Coveralls] Set up the SimpleCov formatter.
[Coveralls] Using SimpleCov's default settings.
..................................................

Deprecation Warnings:

Using `should_receive` from rspec-mocks' old `:should` syntax without explicitly enabling the syntax is deprecated. Use the new `:expect` syntax or explicitly enable `:should` instead. Called from /Users/kendam/workspace/r509-ocsp-responder/spec/server_spec.rb:57:in `block (2 levels) in <top (required)>'.

Using `should` from rspec-expectations' old `:should` syntax without explicitly enabling the syntax is deprecated. Use the new `:expect` syntax or explicitly enable `:should` with `config.expect_with(:rspec) { |c| c.syntax = :should }` instead. Called from /Users/kendam/workspace/r509-ocsp-responder/spec/server_spec.rb:51:in `block (2 levels) in <top (required)>'.


If you need more of the backtrace for any of these deprecations to
identify where to make the necessary changes, you can configure
`config.raise_errors_for_deprecations!`, and it will turn the
deprecation warnings into errors, giving you the full backtrace.

2 deprecation warnings total

Finished in 0.30588 seconds (files took 0.36111 seconds to load)
50 examples, 0 failures


Responder Response
====================

~/w/r509-ocsp-responder ❯❯❯ openssl ocsp -issuer spec/fixtures/test_ca.cer -CAfile spec/fixtures/test_ca.cer -cert spec/fixtures/cert1.pem -text -url http://0.0.0.0:9292
OCSP Request Data:
    Version: 1 (0x0)
    Requestor List:
        Certificate ID:
          Hash Algorithm: sha1
          Issuer Name Hash: 35988E16C384792D9890DBDE698F8385FF8E32C8
          Issuer Key Hash: 7975BB843ACB2CDE7A09BE311B43BC1C2A4D5358
          Serial Number: 314786F263
    Request Extensions:
        OCSP Nonce:
            04108E4180B1EA5AFF6E4798D10F25FCBD1C
OCSP Response Data:
    OCSP Response Status: successful (0x0)
    Response Type: Basic OCSP Response
    Version: 1 (0x0)
    Responder Id: C = US, ST = Illinois, L = Chicago, O = r509 LLC, CN = r509 OCSP Signer
    Produced At: Apr 26 18:48:05 2017 GMT
    Responses:
    Certificate ID:
      Hash Algorithm: sha1
      Issuer Name Hash: 35988E16C384792D9890DBDE698F8385FF8E32C8
      Issuer Key Hash: 7975BB843ACB2CDE7A09BE311B43BC1C2A4D5358
      Serial Number: 314786F263
    Cert Status: unknown
    This Update: Apr 26 17:48:05 2017 GMT
    Next Update: May  3 18:48:05 2017 GMT

    Response Extensions:
        OCSP Nonce:
            04108E4180B1EA5AFF6E4798D10F25FCBD1C
    Signature Algorithm: sha256WithRSAEncryption
        6c:d9:c2:28:a5:d3:8b:da:bd:af:b8:b1:94:28:b4:ba:57:32:
        cc:c8:74:55:9a:83:cd:45:26:f7:96:aa:f1:e1:06:26:e3:c2:
        57:a7:61:f2:90:9e:86:c8:63:5f:18:e4:74:ae:ef:fd:b7:45:
        e9:a8:8d:64:1d:80:08:0f:07:e8:aa:6e:47:c8:35:e4:10:b4:
        27:fb:93:8c:b9:e0:b7:08:4b:a5:c2:c2:9f:30:8d:47:2f:7c:
        b1:b0:8a:2d:10:1b:92:88:42:44:c9:a6:7c:08:4d:8d:34:1d:
        6b:bd:14:82:0b:35:2a:8c:b3:91:49:f1:6c:b7:5f:69:ef:7f:
        db:2a:60:ce:50:59:6d:c3:2b:da:ce:f5:86:dd:2c:a4:5d:80:
        86:b7:61:38:d0:bf:83:a7:1d:92:05:5a:5f:57:b5:42:e6:06:
        fa:85:75:d8:f5:7c:6b:06:4a:cc:81:c0:4f:d1:e1:9b:37:0b:
        75:93:af:93:99:4b:92:28:75:6c:2f:c9:a4:ca:ef:3c:73:28:
        c8:1d:0f:7c:8b:76:60:24:7e:18:36:87:f2:c1:6f:94:03:ea:
        28:50:82:fb:f6:84:81:11:a4:6d:c7:b2:76:5f:31:77:05:4e:
        c5:fb:1b:c8:b3:02:fe:fd:cc:a2:0d:ab:ab:89:1c:0a:61:a6:
        c5:d0:6a:45
Certificate:
    Data:
        Version: 3 (0x2)
        Serial Number:
            be:8a:42:9e:2a:d2:50:67:95:38:37:7d:d9:35:55:68:74:da:ca:ae
        Signature Algorithm: sha1WithRSAEncryption
        Issuer: C=US, ST=Illinois, L=Chicago, O=Ruby CA Project, CN=Test CA
        Validity
            Not Before: Jan  6 10:26:26 2012 GMT
            Not After : Jan  3 16:26:26 2022 GMT
        Subject: C=US, ST=Illinois, L=Chicago, O=r509 LLC, CN=r509 OCSP Signer
        Subject Public Key Info:
            Public Key Algorithm: rsaEncryption
            RSA Public Key: (2048 bit)
                Modulus (2048 bit):
                    00:bd:5b:8f:a9:7d:7d:75:b1:17:17:57:22:5c:d1:
                    7b:05:0a:70:c2:23:4a:f7:a1:a4:be:63:08:9f:fb:
                    02:a7:a3:7e:c5:7a:2b:56:a5:97:d0:a0:3a:85:c5:
                    d6:3e:df:01:3f:08:91:cb:b0:70:84:1a:ab:7c:c0:
                    57:5b:d7:c5:8b:47:46:25:a5:41:f6:1e:5d:25:aa:
                    cf:04:3c:5b:30:40:cc:86:ba:1d:13:19:c6:d8:db:
                    17:37:eb:00:f5:84:29:13:72:3a:51:7f:47:df:3e:
                    55:30:f6:30:24:5b:6d:e5:4f:2d:19:0e:b7:31:ee:
                    88:6d:31:6a:9f:af:55:b1:86:ed:b3:be:92:df:1c:
                    46:d8:55:75:89:b5:82:42:0f:e0:ec:7b:71:28:be:
                    24:04:7d:26:c6:4b:d6:49:3e:42:12:20:53:d0:4a:
                    13:80:52:d2:2a:2b:8c:2f:c5:5c:77:7a:97:7b:9b:
                    d4:30:a8:28:fa:f9:97:0d:7a:32:99:8b:c2:18:e7:
                    9f:49:b2:03:2e:85:af:87:93:02:be:bd:bc:3a:00:
                    fc:ab:68:b3:31:56:3b:61:1a:42:c5:b4:ac:97:11:
                    8f:02:80:7e:58:81:42:ed:5b:57:37:e1:04:4a:68:
                    d9:f1:70:8c:7f:72:77:1a:7b:35:61:c8:7f:ef:f2:
                    d7:21
                Exponent: 65537 (0x10001)
        X509v3 extensions:
            X509v3 Basic Constraints: critical
                CA:FALSE
            X509v3 Extended Key Usage:
                OCSP Signing
            X509v3 Subject Key Identifier:
                4E:D0:65:E5:45:C6:DE:BB:4B:BB:51:D4:5B:85:18:0F:83:8D:38:8C
            X509v3 Authority Key Identifier:
                keyid:79:75:BB:84:3A:CB:2C:DE:7A:09:BE:31:1B:43:BC:1C:2A:4D:53:58
                DirName:/C=US/ST=Illinois/L=Chicago/O=Ruby CA Project/CN=Test CA
                serial:FF:D9:C7:0B:87:37:D1:94

            X509v3 CRL Distribution Points:
                URI:http://crl.r509.org/test_ca.crl

    Signature Algorithm: sha1WithRSAEncryption
        01:8c:66:0f:a9:f3:81:a3:0b:48:33:79:06:51:3a:a4:ba:b3:
        81:83:26:04:67:d3:f9:04:a6:74:90:3b:cc:03:b2:32:e3:cb:
        2c:db:5b:cc:48:c9:7f:70:d4:47:55:69:24:bc:99:37:bf:a1:
        9f:52:bc:c4:bc:38:d1:e5:20:dc:90:b4:cd:06:b9:2e:8e:3b:
        1b:44:41:cc:79:fc:82:71:74:2f:93:0d:74:36:ed:3b:c1:80:
        d8:36:29:42:16:c4:38:06:f5:5d:7c:8d:d4:bf:7d:5d:e9:0c:
        56:d4:7e:e9:46:72:24:24:52:b4:5e:0a:37:21:33:9d:97:52:
        0d:26:6f:5d:d5:08:22:e3:11:41:13:3d:56:15:e9:a9:0e:82:
        09:4c:2e:0d:b6:8d:ed:c5:e9:f8:84:72:dc:07:1c:c0:01:bf:
        a7:ce:4a:b2:9a:dd:08:34:48:2c:75:58:0f:ae:1c:b9:eb:2e:
        37:39:bd:89:63:03:3b:d0:63:3f:14:cb:0a:12:44:19:d6:e9:
        42:27:62:f0:6c:e8:a6:66:5a:ff:5a:71:61:9e:c3:7a:50:2c:
        ea:74:f8:53:ab:be:09:f1:2d:61:bb:0f:84:2e:32:e9:5a:62:
        02:8f:d5:ca:55:6a:59:94:88:29:30:e0:57:c9:a9:e0:c1:4f:
        1a:de:9c:5e
-----BEGIN CERTIFICATE-----
MIIEWjCCA0KgAwIBAgIVAL6KQp4q0lBnlTg3fdk1VWh02squMA0GCSqGSIb3DQEB
BQUAMF4xCzAJBgNVBAYTAlVTMREwDwYDVQQIDAhJbGxpbm9pczEQMA4GA1UEBwwH
Q2hpY2FnbzEYMBYGA1UECgwPUnVieSBDQSBQcm9qZWN0MRAwDgYDVQQDDAdUZXN0
IENBMB4XDTEyMDEwNjEwMjYyNloXDTIyMDEwMzE2MjYyNlowYDELMAkGA1UEBhMC
VVMxETAPBgNVBAgMCElsbGlub2lzMRAwDgYDVQQHDAdDaGljYWdvMREwDwYDVQQK
DAhyNTA5IExMQzEZMBcGA1UEAwwQcjUwOSBPQ1NQIFNpZ25lcjCCASIwDQYJKoZI
hvcNAQEBBQADggEPADCCAQoCggEBAL1bj6l9fXWxFxdXIlzRewUKcMIjSvehpL5j
CJ/7AqejfsV6K1all9CgOoXF1j7fAT8IkcuwcIQaq3zAV1vXxYtHRiWlQfYeXSWq
zwQ8WzBAzIa6HRMZxtjbFzfrAPWEKRNyOlF/R98+VTD2MCRbbeVPLRkOtzHuiG0x
ap+vVbGG7bO+kt8cRthVdYm1gkIP4Ox7cSi+JAR9JsZL1kk+QhIgU9BKE4BS0ior
jC/FXHd6l3ub1DCoKPr5lw16MpmLwhjnn0myAy6Fr4eTAr69vDoA/KtoszFWO2Ea
QsW0rJcRjwKAfliBQu1bVzfhBEpo2fFwjH9ydxp7NWHIf+/y1yECAwEAAaOCAQsw
ggEHMAwGA1UdEwEB/wQCMAAwEwYDVR0lBAwwCgYIKwYBBQUHAwkwHQYDVR0OBBYE
FE7QZeVFxt67S7tR1FuFGA+DjTiMMIGQBgNVHSMEgYgwgYWAFHl1u4Q6yyzeegm+
MRtDvBwqTVNYoWKkYDBeMQswCQYDVQQGEwJVUzERMA8GA1UECAwISWxsaW5vaXMx
EDAOBgNVBAcMB0NoaWNhZ28xGDAWBgNVBAoMD1J1YnkgQ0EgUHJvamVjdDEQMA4G
A1UEAwwHVGVzdCBDQYIJAP/ZxwuHN9GUMDAGA1UdHwQpMCcwJaAjoCGGH2h0dHA6
Ly9jcmwucjUwOS5vcmcvdGVzdF9jYS5jcmwwDQYJKoZIhvcNAQEFBQADggEBAAGM
Zg+p84GjC0gzeQZROqS6s4GDJgRn0/kEpnSQO8wDsjLjyyzbW8xIyX9w1EdVaSS8
mTe/oZ9SvMS8ONHlINyQtM0GuS6OOxtEQcx5/IJxdC+TDXQ27TvBgNg2KUIWxDgG
9V18jdS/fV3pDFbUfulGciQkUrReCjchM52XUg0mb13VCCLjEUETPVYV6akOgglM
Lg22je3F6fiEctwHHMABv6fOSrKa3Qg0SCx1WA+uHLnrLjc5vYljAzvQYz8UywoS
RBnW6UInYvBs6KZmWv9acWGew3pQLOp0+FOrvgnxLWG7D4QuMulaYgKP1cpValmU
iCkw4FfJqeDBTxrenF4=
-----END CERTIFICATE-----
Response Verify Failure
98745:error:27069070:OCSP routines:OCSP_basic_verify:root ca not trusted:/BuildRoot/Library/Caches/com.apple.xbs/Sources/OpenSSL098/OpenSSL098-64.50.6/src/crypto/ocsp/ocsp_vfy.c:152:
spec/fixtures/cert1.pem: unknown